### PR TITLE
feat(core): add annotation-based Redis cache support

### DIFF
--- a/jredom-core/src/main/java/com/rockstonegames/jredom/annotation/CacheOperationType.java
+++ b/jredom-core/src/main/java/com/rockstonegames/jredom/annotation/CacheOperationType.java
@@ -1,0 +1,21 @@
+package com.rockstonegames.jredom.annotation;
+
+/**
+ * Redis缓存操作类型
+ */
+public enum CacheOperationType {
+    /**
+     * 保存或更新缓存
+     */
+    SAVE,
+    
+    /**
+     * 删除缓存
+     */
+    DELETE,
+    
+    /**
+     * 刷新缓存
+     */
+    REFRESH
+}

--- a/jredom-core/src/main/java/com/rockstonegames/jredom/annotation/RedisCache.java
+++ b/jredom-core/src/main/java/com/rockstonegames/jredom/annotation/RedisCache.java
@@ -1,0 +1,29 @@
+package com.rockstonegames.jredom.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 标记需要同步到Redis缓存的方法
+ * 当标记的方法被调用时，会自动同步数据到Redis
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface RedisCache {
+    /**
+     * 缓存操作类型
+     */
+    CacheOperationType operation() default CacheOperationType.SAVE;
+    
+    /**
+     * 实体ID的参数索引，默认为0
+     */
+    int idParamIndex() default 0;
+    
+    /**
+     * 缓存过期时间（分钟）
+     */
+    int expireMinutes() default 30;
+}

--- a/jredom-core/src/main/java/com/rockstonegames/jredom/aop/RedisCacheAspect.java
+++ b/jredom-core/src/main/java/com/rockstonegames/jredom/aop/RedisCacheAspect.java
@@ -1,0 +1,81 @@
+package com.rockstonegames.jredom.aop;
+
+import com.rockstonegames.jredom.annotation.CacheOperationType;
+import com.rockstonegames.jredom.annotation.RedisCache;
+import com.rockstonegames.jredom.core.EntityWithId;
+import com.rockstonegames.jredom.core.RedisCacheManager;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+@Aspect
+@Component
+public class RedisCacheAspect {
+
+    @Autowired
+    private RedisCacheManager cacheManager;
+
+    @Around("@annotation(com.rockstonegames.jredom.annotation.RedisCache)")
+    public Object handleRedisCache(ProceedingJoinPoint joinPoint) throws Throwable {
+        // 获取方法签名
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        
+        // 获取注解
+        RedisCache redisCache = method.getAnnotation(RedisCache.class);
+        
+        // 获取参数
+        Object[] args = joinPoint.getArgs();
+        
+        // 执行原方法
+        Object result = joinPoint.proceed();
+        
+        // 根据操作类型处理缓存
+        switch (redisCache.operation()) {
+            case SAVE:
+                handleSaveOperation(result, redisCache.expireMinutes());
+                break;
+            case DELETE:
+                handleDeleteOperation(args, redisCache.idParamIndex());
+                break;
+            case REFRESH:
+                handleRefreshOperation(args, redisCache.idParamIndex());
+                break;
+        }
+        
+        return result;
+    }
+    
+    private void handleSaveOperation(Object result, int expireMinutes) {
+        if (result instanceof EntityWithId) {
+            EntityWithId<?> entity = (EntityWithId<?>) result;
+            String key = com.rockstonegames.jredom.core.CacheKeyGenerator.generate(
+                    entity.getClass(), entity.getId());
+            cacheManager.put(key, entity, Duration.ofMinutes(expireMinutes));
+        }
+    }
+    
+    private void handleDeleteOperation(Object[] args, int idParamIndex) {
+        if (args.length > idParamIndex) {
+            Object id = args[idParamIndex];
+            // 需要知道实体类型，这里简化处理
+            if (args.length > idParamIndex + 1 && args[idParamIndex + 1] instanceof Class) {
+                Class<?> entityClass = (Class<?>) args[idParamIndex + 1];
+                String key = com.rockstonegames.jredom.core.CacheKeyGenerator.generate(
+                        entityClass, id);
+                cacheManager.delete(key);
+            }
+        }
+    }
+    
+    private void handleRefreshOperation(Object[] args, int idParamIndex) {
+        // 刷新操作实际上就是删除缓存
+        handleDeleteOperation(args, idParamIndex);
+    }
+}

--- a/jredom-core/src/main/java/com/rockstonegames/jredom/core/RedisOrmFunction.java
+++ b/jredom-core/src/main/java/com/rockstonegames/jredom/core/RedisOrmFunction.java
@@ -1,6 +1,6 @@
 package com.rockstonegames.jredom.core;
 
 @FunctionalInterface
-public interface RedisOrmFunction {
-    void execute();
+public interface RedisOrmFunction<T> {
+    void execute(T t);
 }

--- a/jredom-examples/src/main/java/io/github/redis/orm/example/AnnotationExample.java
+++ b/jredom-examples/src/main/java/io/github/redis/orm/example/AnnotationExample.java
@@ -1,0 +1,37 @@
+package io.github.redis.orm.example;
+
+import io.github.redis.orm.example.entity.User;
+import io.github.redis.orm.example.service.AnnotationUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnotationExample implements CommandLineRunner {
+
+    @Autowired
+    private AnnotationUserService annotationUserService;
+
+    @Override
+    public void run(String... args) {
+        System.out.println("=== 使用注解方式的Redis ORM示例 ===");
+        
+        // 创建用户
+        User user = new User(null, "annotation_user", "annotation@example.com");
+        user = annotationUserService.createUser(user);
+        System.out.println("创建用户 (注解方式): " + user.getId());
+        
+        // 更新用户
+        user.setEmail("annotation.updated@example.com");
+        annotationUserService.updateUser(user);
+        System.out.println("更新用户 (注解方式)");
+        
+        // 获取用户
+        User retrievedUser = annotationUserService.getUser(user.getId());
+        System.out.println("获取用户 (注解方式): " + retrievedUser.getEmail());
+        
+        // 删除用户
+        annotationUserService.deleteUser(user.getId(), User.class);
+        System.out.println("删除用户 (注解方式)");
+    }
+}

--- a/jredom-examples/src/main/java/io/github/redis/orm/example/UserExample.java
+++ b/jredom-examples/src/main/java/io/github/redis/orm/example/UserExample.java
@@ -1,5 +1,6 @@
 package io.github.redis.orm.example;
 
+import com.rockstonegames.jredom.core.RedisOrmFunction;
 import io.github.redis.orm.example.entity.User;
 import io.github.redis.orm.example.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,9 +22,12 @@ public class UserExample implements CommandLineRunner {
 
         // Using new pattern with inner function
         User user2 = new User(null, "jane_doe", "jane@example.com");
-        user2 = userService.createUser(user2, () -> {
+        user2 = userService.createUser(user2, new RedisOrmFunction() {
+          @Override
+          public void execute(Object o) {
             // Custom Redis operations here
             System.out.println("Executing custom Redis operation");
+          }
         });
         System.out.println("Created user (new pattern): " + user2.getId());
 
@@ -33,16 +37,22 @@ public class UserExample implements CommandLineRunner {
 
         // Update example with new pattern
         user2.setEmail("jane.updated@example.com");
-        userService.updateUser(user2, () -> {
+        userService.updateUser(user2, new RedisOrmFunction<User>() {
+          @Override
+          public void execute(User user) {
             // Custom Redis operations here
             System.out.println("Executing custom Redis update operation");
+          }
         });
 
         // Delete examples
         userService.deleteUser(user1.getId()); // Original pattern
-        userService.deleteUser(user2.getId(), () -> {
+        userService.deleteUser(user2.getId(), new RedisOrmFunction<Long>() {
+          @Override
+          public void execute(Long aLong) {
             // Custom Redis delete operation
             System.out.println("Executing custom Redis delete operation");
+          }
         });
     }
 }

--- a/jredom-examples/src/main/java/io/github/redis/orm/example/service/AnnotationUserService.java
+++ b/jredom-examples/src/main/java/io/github/redis/orm/example/service/AnnotationUserService.java
@@ -1,0 +1,58 @@
+package io.github.redis.orm.example.service;
+
+import com.rockstonegames.jredom.annotation.CacheOperationType;
+import com.rockstonegames.jredom.annotation.RedisCache;
+import io.github.redis.orm.example.entity.User;
+import io.github.redis.orm.example.mapper.UserMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AnnotationUserService {
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Transactional
+    @RedisCache(operation = CacheOperationType.SAVE)
+    public User createUser(User user) {
+        userMapper.insert(user);
+        return user;
+    }
+
+    @Transactional
+    @RedisCache(operation = CacheOperationType.SAVE)
+    public User updateUser(User user) {
+        userMapper.update(user);
+        return user;
+    }
+
+    @Transactional
+    @RedisCache(operation = CacheOperationType.DELETE, idParamIndex = 0)
+    public void deleteUser(Long id, Class<User> userClass) {
+        userMapper.delete(id);
+    }
+
+    public User getUser(Long id) {
+        // 先从Redis获取
+        String key = com.rockstonegames.jredom.core.CacheKeyGenerator.generate(User.class, id);
+        java.util.Optional<User> userFromCache = new com.rockstonegames.jredom.core.RedisCacheManager().get(key, User.class);
+        
+        if (userFromCache.isPresent()) {
+            return userFromCache.get();
+        }
+        
+        // 如果Redis中没有，从数据库获取并缓存
+        User userFromDb = userMapper.findById(id);
+        if (userFromDb != null) {
+            saveToCache(userFromDb);
+        }
+        return userFromDb;
+    }
+    
+    @RedisCache(operation = CacheOperationType.SAVE)
+    private User saveToCache(User user) {
+        return user;
+    }
+}

--- a/jredom-examples/src/main/java/io/github/redis/orm/example/service/UserService.java
+++ b/jredom-examples/src/main/java/io/github/redis/orm/example/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
         userMapper.insert(user);
 
         // 2. Execute custom Redis operation
-        redisOrmFunction.execute();
+        redisOrmFunction.execute(user);
 
         return user;
     }
@@ -56,12 +56,12 @@ public class UserService {
 
     // New pattern with inner function
     @Transactional
-    public User updateUser(User user, RedisOrmFunction redisOrmFunction) {
+    public User updateUser(User user, RedisOrmFunction<User> redisOrmFunction) {
         // 1. Update MySQL
         userMapper.update(user);
 
         // 2. Execute custom Redis operation
-        redisOrmFunction.execute();
+        redisOrmFunction.execute(user);
 
         return user;
     }
@@ -77,12 +77,12 @@ public class UserService {
 
     // New pattern with inner function
     @Transactional
-    public void deleteUser(Long id, RedisOrmFunction redisOrmFunction) {
+    public void deleteUser(Long id, RedisOrmFunction<Long> redisOrmFunction) {
         // 1. Delete from MySQL
         userMapper.delete(id);
 
         // 2. Execute custom Redis operation
-        redisOrmFunction.execute();
+        redisOrmFunction.execute(id);
     }
 
     public User getUser(Long id) {

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Add @RedisCache annotation and AOP aspect for declarative Redis cache management. Key features include:
- Create RedisCache annotation supporting SAVE/DELETE/REFRESH operations
- Implement RedisCacheAspect to handle annotation logic
- Add example code demonstrating annotation usage