### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/free-pixel/jredom/security/code-scanning/1](https://github.com/free-pixel/jredom/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimum required permissions. Since the workflow only needs to read repository contents (e.g., to build the project and update the dependency graph), the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
